### PR TITLE
Update Giara runtime to 46

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,60 @@
+From 29863599df3693a2c7a21e6631ea364b737862b6 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sat, 8 Jun 2024 16:45:25 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ data/org.gabmus.giara.appdata.xml.in | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/data/org.gabmus.giara.appdata.xml.in b/data/org.gabmus.giara.appdata.xml.in
+index a05e3b7..767fdab 100644
+--- a/data/org.gabmus.giara.appdata.xml.in
++++ b/data/org.gabmus.giara.appdata.xml.in
+@@ -19,19 +19,33 @@
+     <screenshots>
+         <screenshot type="default">
+             <image>https://gitlab.gnome.org/World/giara/raw/website/static/screenshots/mainwindow.png</image>
++        </screenshot>
++        <screenshot>
+             <image>https://gitlab.gnome.org/World/giara/raw/website/static/screenshots/scrot01.png</image>
++        </screenshot>
++        <screenshot>
+             <image>https://gitlab.gnome.org/World/giara/raw/website/static/screenshots/scrot02.png</image>
++        </screenshot>
++        <screenshot>
+             <image>https://gitlab.gnome.org/World/giara/raw/website/static/screenshots/scrot03.png</image>
++        </screenshot>
++        <screenshot>
+             <image>https://gitlab.gnome.org/World/giara/raw/website/static/screenshots/scrot04.png</image>
++        </screenshot>
++        <screenshot>
+             <image>https://gitlab.gnome.org/World/giara/raw/website/static/screenshots/scrot05.png</image>
++        </screenshot>
++        <screenshot>
+             <image>https://gitlab.gnome.org/World/giara/raw/website/static/screenshots/scrot06.png</image>
++        </screenshot>
++        <screenshot>
+             <image>https://gitlab.gnome.org/World/giara/raw/website/static/screenshots/scrot07.png</image>
+         </screenshot>
+     </screenshots>
+     <url type="homepage">https://giara.gabmus.org</url>
+     <url type="bugtracker">https://gitlab.gnome.org/World/giara/-/issues</url>
++    <url type="vcs-browser">https://gitlab.gnome.org/World/giara</url>
+     <url type="translate">https://gitlab.gnome.org/World/giara/-/tree/master/po</url>
+-    <url type="donation">https://liberapay.com/gabmus/donate</url>
+     <update_contact>gabmus@disroot.org</update_contact>
+     <releases>
+         <release version="1.1.0" timestamp="1679827407">
+@@ -125,7 +139,6 @@
+         <content_attribute id="social-chat">moderate</content_attribute>
+     </content_rating>
+     <custom>
+-        <value key="Purism::form_factor">workstation</value>
+         <value key="Purism::form_factor">mobile</value>
+     </custom>
+ </component>
+--
+libgit2 1.7.2
+

--- a/org.gabmus.giara.json
+++ b/org.gabmus.giara.json
@@ -2,7 +2,7 @@
     "app-id": "org.gabmus.giara",
     "command": "giara",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "finish-args": [
         "--device=dri",
@@ -14,7 +14,7 @@
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
-            "version": "22.08.9",
+            "version": "23.08",
             "add-ld-path": ".",
             "no-autodownload": true,
             "autodelete": false

--- a/org.gabmus.giara.json
+++ b/org.gabmus.giara.json
@@ -50,6 +50,10 @@
                     "type": "git",
                     "url": "https://gitlab.gnome.org/World/giara",
                     "tag": "1.1.0"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix_appdata.patch"
                 }
             ]
         }


### PR DESCRIPTION
- Update Giara runtime to 46 since runtime version 44 has reached end-of-life.
- Update ffmpeg extension version
- Fix appdata papercuts